### PR TITLE
Test flexibility

### DIFF
--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CompositeParsers/DelegatorInvokesDelegateRuleWithArgs.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CompositeParsers/DelegatorInvokesDelegateRuleWithArgs.stg
@@ -28,5 +28,5 @@ WS : (' '|'\n') -> skip ;
 
 slaveGrammar(grammarName) ::= <<
 parser grammar S;
-a[int x] returns [int y] : B {<write("\"S.a\"")>} {$y=1000;} ;
+a[<IntType()> x] returns [<IntType()> y] : B {<write("\"S.a\"")>} {$y=1000;} ;
 >>

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CompositeParsers/ImportedRuleWithAction.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/CompositeParsers/ImportedRuleWithAction.stg
@@ -28,5 +28,5 @@ WS : (' '|'\n') -> skip ;
 // wasn't terminating. @after was injected into M as if it were @members
 slaveGrammar(grammarName) ::= <<
 parser grammar S;
-a @after {<InitIntMember("x","0")>} : B;
+a @after {<InitLocalIntMember("x","0")>} : B;
 >>

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/AmbigYieldsCtxSensitiveDFA.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/AmbigYieldsCtxSensitiveDFA.stg
@@ -23,6 +23,9 @@ line 1:0 reportAmbiguity d=0 (s): ambigAlts={1, 2}, input='abc'<\n>
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
+
+<ImportPredictionMode()>
+
 s
 @init {<LL_EXACT_AMBIG_DETECTION()>}
 @after {<DumpDFA()>}

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/AmbiguityNoLoop.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/AmbiguityNoLoop.stg
@@ -25,6 +25,9 @@ line 1:2 reportContextSensitivity d=1 (expr), input='a@'<\n>
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
+
+<ImportPredictionMode()>
+
 prog
 @init {<LL_EXACT_AMBIG_DETECTION()>}
 	: expr expr {<writeln("\"alt 1\"")>}

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/CtxSensitiveDFATwoDiffInputWithDFA.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/CtxSensitiveDFATwoDiffInputWithDFA.stg
@@ -33,7 +33,7 @@ line 1:14 reportContextSensitivity d=2 (e), input='34abc'<\n>
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
-s @init{getInterpreter().enable_global_context_dfa = true;} @after {<DumpDFA()>}
+s @init{<FULL_CONTEXT_DFA()>} @after {<DumpDFA()>}
   : ('$' a | '@' b)+ ;
 a : e ID ;
 b : e INT ID ;

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/CtxSensitiveWithDFA.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/CtxSensitiveWithDFA.stg
@@ -12,7 +12,7 @@ Rule() ::= "s"
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
-s @init{getInterpreter().enable_global_context_dfa = true;} @after {<DumpDFA()>}
+s @init{<FULL_CONTEXT_DFA()>} @after {<DumpDFA()>}
   : '$' a | '@' b ;
 a : e ID ;
 b : e INT ID ;

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/ExprAmbiguity.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/ExprAmbiguity.stg
@@ -15,7 +15,7 @@ grammar <grammarName>;
 s
 @init {<LL_EXACT_AMBIG_DETECTION()>}
 :   expr[0] {<ToStringTree("$expr.ctx"):writeln()>};
-	expr[int _p]
+	expr[<IntType()> _p]
 		: ID 
 		( 
 			{5 >= $_p}? '*' expr[6]

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/ExprAmbiguity.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/ExprAmbiguity.stg
@@ -12,6 +12,9 @@ Rule() ::= "s"
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
+
+<ImportPredictionMode()>
+
 s
 @init {<LL_EXACT_AMBIG_DETECTION()>}
 :   expr[0] {<ToStringTree("$expr.ctx"):writeln()>};

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/FullContextIF_THEN_ELSEParse_WithDFA.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/FullContextIF_THEN_ELSEParse_WithDFA.stg
@@ -13,7 +13,7 @@ Rule() ::= "s"
 grammar(grammarName) ::= <<
 grammar <grammarName>;
 s 
-@init {getInterpreter().enable_global_context_dfa = true; <LL_EXACT_AMBIG_DETECTION()>}
+@init {<FULL_CONTEXT_DFA()> <LL_EXACT_AMBIG_DETECTION()>}
 @after {<DumpDFA()>}
 	: '{' stat* '}' ;
 stat: 'if' ID 'then' stat ('else' ID)?

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/FullContextIF_THEN_ELSEParse_WithDFA.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/FullContextIF_THEN_ELSEParse_WithDFA.stg
@@ -12,6 +12,9 @@ Rule() ::= "s"
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
+
+<ImportPredictionMode()>
+
 s 
 @init {<FULL_CONTEXT_DFA()> <LL_EXACT_AMBIG_DETECTION()>}
 @after {<DumpDFA()>}

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/FullContextIF_THEN_ELSEParse_WithoutDFA.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/FullContextIF_THEN_ELSEParse_WithoutDFA.stg
@@ -12,6 +12,9 @@ Rule() ::= "s"
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
+
+<ImportPredictionMode()>
+
 s 
 @init {<LL_EXACT_AMBIG_DETECTION()>}
 @after {<DumpDFA()>}

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/LoopsSimulateTailRecursion.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/LoopsSimulateTailRecursion.stg
@@ -27,6 +27,9 @@ line 1:7 reportAmbiguity d=3 (expr_primary): ambigAlts={2, 3}, input='a(i)\<-x'<
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
+
+<ImportPredictionMode()>
+
 prog
 @init {<LL_EXACT_AMBIG_DETECTION()>}
 	: expr_or_assign*;

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/SLLSeesEOFInLLGrammarWithDFA.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/FullContextParsing/SLLSeesEOFInLLGrammarWithDFA.stg
@@ -27,7 +27,7 @@ line 1:0 reportContextSensitivity d=0 (e), input='34'<\n>
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
-s @init{getInterpreter().enable_global_context_dfa = true;} @after {<DumpDFA()>}
+s @init{<FULL_CONTEXT_DFA()>} @after {<DumpDFA()>}
   : a;
 a : e ID ;
 b : e INT ID ;

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/LeftRecursion/MultipleAlternativesWithCommonLabel.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/LeftRecursion/MultipleAlternativesWithCommonLabel.stg
@@ -20,7 +20,7 @@ Rule() ::= "s"
 grammar(grammarName) ::= <<
 grammar <grammarName>;
 s : e {<writeln("$e.v")>};
-e returns [int v]
+e returns [<IntType()> v]
   : e '*' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> * <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
   | e '+' e     {$v = <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(0)}, {<Result("v")>})> + <Cast("BinaryContext","$ctx"):ContextMember({<Production("e")>(1)}, {<Result("v")>})>;}  # binary
   | INT         {$v = $INT.int;}                   # anInt

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/LeftRecursion/ReturnValueAndActions.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/LeftRecursion/ReturnValueAndActions.stg
@@ -13,7 +13,7 @@ Rule() ::= "s"
 grammar(grammarName) ::= <<
 grammar <grammarName>;
 s : e {<writeln("$e.v")>}; 
-e returns [int v, <StringList()> ignored]
+e returns [<IntType()> v, <StringList()> ignored]
   : a=e '*' b=e {$v = $a.v * $b.v;}
   | a=e '+' b=e {$v = $a.v + $b.v;}
   | INT {$v = $INT.int;}

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/LeftRecursion/ReturnValueAndActionsAndLabels.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/LeftRecursion/ReturnValueAndActionsAndLabels.stg
@@ -13,7 +13,7 @@ Rule() ::= "s"
 grammar(grammarName) ::= <<
 grammar <grammarName>;
 s : q=e {<writeln("$e.v")>}; 
-e returns [int v]
+e returns [<IntType()> v]
   : a=e op='*' b=e {$v = $a.v * $b.v;}  # mult
   | a=e '+' b=e {$v = $a.v + $b.v;}     # add
   | INT         {$v = $INT.int;}        # anInt

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/LexerExec/PositionAdjustingLexer.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/LexerExec/PositionAdjustingLexer.stg
@@ -35,9 +35,7 @@ Errors() ::= ""
 grammar(grammarName) ::= <<
 lexer grammar PositionAdjustingLexer;
 
-@members {
 <PositionAdjustingLexer()>
-}
 
 ASSIGN : '=' ;
 PLUS_ASSIGN : '+=' ;

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Listeners/Basic.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Listeners/Basic.stg
@@ -28,8 +28,8 @@ grammar <grammarName>;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextLabel("$ctx", "r"):ToStringTree():writeln()>
+<ContextLabel("$ctx", "r"):WalkListener()>
 }
   : r=a ;
 a : INT INT

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Listeners/LR.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Listeners/LR.stg
@@ -31,8 +31,8 @@ grammar <grammarName>;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextLabel("$ctx", "r"):ToStringTree():writeln()>
+<ContextLabel("$ctx", "r"):WalkListener()>
 }
 	: r=e ;
 e : e op='*' e

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Listeners/LRWithLabels.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Listeners/LRWithLabels.stg
@@ -30,8 +30,8 @@ grammar <grammarName>;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextLabel("$ctx", "r"):ToStringTree():writeln()>
+<ContextLabel("$ctx", "r"):WalkListener()>
 }
   : r=e ;
 e : e '(' eList ')' # Call

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Listeners/RuleGetters.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Listeners/RuleGetters.stg
@@ -18,8 +18,8 @@ grammar <grammarName>;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextLabel("$ctx", "r"):ToStringTree():writeln()>
+<ContextLabel("$ctx", "r"):WalkListener()>
 }
   : r=a ;
 a : b b		// forces list

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Listeners/TokenGetters.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/Listeners/TokenGetters.stg
@@ -18,8 +18,8 @@ grammar <grammarName>;
 
 s
 @after {
-<ContextRuleFunction("$ctx", "r"):ToStringTree():writeln()>
-<ContextRuleFunction("$ctx", "r"):WalkListener()>
+<ContextLabel("$ctx", "r"):ToStringTree():writeln()>
+<ContextLabel("$ctx", "r"):WalkListener()>
 }
   : r=a ;
 a : INT INT

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/ParserExec/PredictionIssue334.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/ParserExec/PredictionIssue334.stg
@@ -26,6 +26,9 @@ Errors() ::= ""
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
+
+<ImportBailErrorStrategy()>
+
 file_ @init{
 <BailErrorStrategy()>
 } 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/2UnpredicatedAlts.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/2UnpredicatedAlts.stg
@@ -28,6 +28,9 @@ line 1:3 reportAmbiguity d=0 (a): ambigAlts={1, 2}, input='y'<\n>
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
+
+<ImportPredictionMode()>
+
 s : {<LL_EXACT_AMBIG_DETECTION()>} a ';' a; // do 2x: once in ATN, next in DFA
 a : ID {<writeln("\"alt 1\"")>}
   | ID {<writeln("\"alt 2\"")>}

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/2UnpredicatedAltsAndOneOrthogonalAlt.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/2UnpredicatedAltsAndOneOrthogonalAlt.stg
@@ -27,6 +27,9 @@ line 1:7 reportAmbiguity d=0 (a): ambigAlts={2, 3}, input='y'<\n>
 
 grammar(grammarName) ::= <<
 grammar <grammarName>;
+
+<ImportPredictionMode()>
+
 s : {<LL_EXACT_AMBIG_DETECTION()>} a ';' a ';' a;
 a : INT {<writeln("\"alt 1\"")>}
   | ID {<writeln("\"alt 2\"")>} // must pick this one for ID since pred is false

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/AtomWithClosureInTranslatedLRRule.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/AtomWithClosureInTranslatedLRRule.stg
@@ -25,7 +25,7 @@ Errors() ::= ""
 grammar(grammarName) ::= <<
 grammar <grammarName>;
 start : e[0] EOF;
-e[int _p]
+e[<IntType()> _p]
     :   ( 'a' | 'b'+ ) ( {3 >= $_p}? '+' e[4] )*
     ;
 

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.stg
@@ -29,8 +29,8 @@ grammar <grammarName>;
 <Declare_pred()>
 }
 s : a[99] ;
-a[int i] : e {<ValEquals("$i","99"):Invoke_pred()>}? {<writeln("\"parse\"")>} '!' ;
-b[int i] : e {<ValEquals("$i","99"):Invoke_pred()>}? ID ;
+a[<IntType()> i] : e {<ValEquals("$i","99"):Invoke_pred()>}? {<writeln("\"parse\"")>} '!' ;
+b[<IntType()> i] : e {<ValEquals("$i","99"):Invoke_pred()>}? ID ;
 e : ID | ; // non-LL(1) so we use ATN
 ID : 'a'..'z'+ ;
 INT : '0'..'9'+;

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.stg
@@ -23,8 +23,8 @@ Errors() ::= ""
 grammar(grammarName) ::= <<
 grammar <grammarName>;
 s : b[2] ';' |  b[2] '.' ; // decision in s drills down to ctx-dependent pred in a;
-b[int i] : a[i] ;
-a[int i]
+b[<IntType()> i] : a[i] ;
+a[<IntType()> i]
   : {<ValEquals("$i","1")>}? ID {<writeln("\"alt 1\"")>}
     | {<ValEquals("$i","2")>}? ID {<writeln("\"alt 2\"")>}
     ;

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/PredicateDependentOnArg.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/PredicateDependentOnArg.stg
@@ -30,7 +30,7 @@ grammar(grammarName) ::= <<
 grammar <grammarName>;
 @parser::members {<InitIntMember("i","0")>}
 s : a[2] a[1];
-a[int i]
+a[<IntType()> i]
   : {<ValEquals("$i","1")>}? ID {<writeln("\"alt 1\"")>}
   | {<ValEquals("$i","2")>}? ID {<writeln("\"alt 2\"")>}
   ;

--- a/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/PredicateDependentOnArg2.stg
+++ b/runtime-testsuite/resources/org/antlr/v4/test/runtime/templates/SemPredEvalParser/PredicateDependentOnArg2.stg
@@ -32,7 +32,7 @@ grammar(grammarName) ::= <<
 grammar <grammarName>;
 @parser::members {<InitIntMember("i","0")>}
 s : a[2] a[1];
-a[int i]
+a[<IntType()> i]
   : {<ValEquals("$i","1")>}? ID 
   | {<ValEquals("$i","2")>}? ID 
   ;

--- a/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
@@ -187,6 +187,7 @@ AssertIsList(v) ::= "List\<?> __ttt__ = <v>;" // just use static type system
 AssignLocal(s,v) ::= "<s> = <v>;"
 
 InitIntMember(n,v) ::= <%int <n> = <v>;%>
+InitLocalIntMember(n, v) ::= InitIntMember
 
 InitBooleanMember(n,v) ::= <%boolean <n> = <v>;%>
 

--- a/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
@@ -237,6 +237,8 @@ TokenStartColumnEquals(i) ::= <%this._tokenStartCharPositionInLine==<i>%>
 
 ImportListener(X) ::= ""
 
+ImportBailErrorStrategy() ::= ""
+
 GetExpectedTokenNames() ::= "this.getExpectedTokens().toString(this.tokenNames)"
 
 RuleInvocationStack() ::= "getRuleInvocationStack()"

--- a/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
@@ -237,6 +237,7 @@ TokenStartColumnEquals(i) ::= <%this._tokenStartCharPositionInLine==<i>%>
 
 ImportListener(X) ::= ""
 
+ImportPredictionMode() ::= ""
 ImportBailErrorStrategy() ::= ""
 
 GetExpectedTokenNames() ::= "this.getExpectedTokens().toString(this.tokenNames)"

--- a/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
@@ -240,6 +240,7 @@ GetExpectedTokenNames() ::= "this.getExpectedTokens().toString(this.tokenNames)"
 
 RuleInvocationStack() ::= "getRuleInvocationStack()"
 
+FULL_CONTEXT_DFA() ::= "getInterpreter().enable_global_context_dfa = true;"
 LL_EXACT_AMBIG_DETECTION() ::= <<_interp.setPredictionMode(PredictionMode.LL_EXACT_AMBIG_DETECTION);>>
 
 ParserToken(parser, token) ::= <%<parser>.<token>%>

--- a/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
@@ -456,6 +456,7 @@ Invoke_pred(v) ::= <<this.pred(<v>)>>
 ParserTokenType(t) ::= "Parser.<t>"
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
 StringType() ::= "String"
+IntType() ::= "int"
 ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"
 isEmpty ::= [
 	"": true,

--- a/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
@@ -460,6 +460,7 @@ Invoke_pred(v) ::= <<this.pred(<v>)>>
 
 ParserTokenType(t) ::= "Parser.<t>"
 ContextRuleFunction(ctx, rule) ::= "<ctx>.<rule>"
+ContextLabel(ctx, label) ::= "<ctx>.<label>"
 StringType() ::= "String"
 IntType() ::= "int"
 ContextMember(ctx, subctx, member) ::= "<ctx>.<subctx>.<member>"

--- a/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
+++ b/tool/test/org/antlr/v4/test/runtime/java/Java.test.stg
@@ -264,7 +264,7 @@ boolean Property() {
 ParserPropertyCall(p, call) ::= "<p>.<call>"
 
 PositionAdjustingLexer() ::= <<
-
+@members {
 @Override
 public Token nextToken() {
 	if (!(_interp instanceof PositionAdjustingLexerATNSimulator)) {
@@ -341,7 +341,7 @@ protected static class PositionAdjustingLexerATNSimulator extends LexerATNSimula
 	}
 
 }
-
+}
 >>
 
 BasicListener(X) ::= <<


### PR DESCRIPTION
Improve test flexibility to address the requirements of the optimized TypeScript target. Prior to these changes, many tests were disabled in that target simply because the test templates did not provide enough flexibility for the tests to be correctly implemented by that target.