### PR TITLE
Implement support for optional getters

### DIFF
--- a/tool/src/org/antlr/v4/codegen/model/decl/ContextRuleGetterDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/ContextRuleGetterDecl.java
@@ -11,8 +11,11 @@ import org.antlr.v4.codegen.OutputModelFactory;
 /** {@code public XContext X() { }} */
 public class ContextRuleGetterDecl extends ContextGetterDecl {
 	public String ctxName;
-	public ContextRuleGetterDecl(OutputModelFactory factory, String name, String ctxName) {
+	public boolean optional;
+
+	public ContextRuleGetterDecl(OutputModelFactory factory, String name, String ctxName, boolean optional) {
 		super(factory, name);
 		this.ctxName = ctxName;
+		this.optional = optional;
 	}
 }

--- a/tool/src/org/antlr/v4/codegen/model/decl/ContextTokenGetterDecl.java
+++ b/tool/src/org/antlr/v4/codegen/model/decl/ContextTokenGetterDecl.java
@@ -10,7 +10,10 @@ import org.antlr.v4.codegen.OutputModelFactory;
 
 /** {@code public Token X() { }} */
 public class ContextTokenGetterDecl extends ContextGetterDecl {
-	public ContextTokenGetterDecl(OutputModelFactory factory, String name) {
+	public boolean optional;
+
+	public ContextTokenGetterDecl(OutputModelFactory factory, String name, boolean optional) {
 		super(factory, name);
+		this.optional = optional;
 	}
 }


### PR DESCRIPTION
This analysis is required for proper code generation in the TypeScript target when strict null checks are enabled.