### PR TITLE
Fix the AppVeyor build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: true
 language: java
+branches:
+  only:
+  - master
 before_script:
   - echo "MAVEN_OPTS='$CUSTOM_MAVEN_OPTS'" > ~/.mavenrc
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 version: '4.7.1-SNAPSHOT+AppVeyor.{build}'
 os: Visual Studio 2015
+branches:
+  only:
+  - master
 build_script:
   - mvn -DskipTests install -q --batch-mode 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,5 +4,3 @@ build_script:
   - mvn -DskipTests install -q --batch-mode 
 test_script:
   - mvn test -Dantlr.testinprocess=true -DJDK_SOURCE_ROOT=../runtime/Java/src -Dperformance.package= -q --batch-mode
-build:
-  verbosity: minimal


### PR DESCRIPTION
* Remove the `build` configuration element, which was preventing the `build_script` section from being recognized
* Only build the **master** branch (and pull requests sent to it)