### PR TITLE
Build cleanup from HashEdgeMap implementation

### DIFF
--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/ArrayEdgeMap.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/ArrayEdgeMap.java
@@ -76,6 +76,7 @@ public final class ArrayEdgeMap<T> extends AbstractEdgeMap<T> {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public ArrayEdgeMap<T> putAll(EdgeMap<? extends T> m) {
 		if (m.isEmpty()) {
 			return this;

--- a/runtime/Java/src/org/antlr/v4/runtime/dfa/HashEdgeMap.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/dfa/HashEdgeMap.java
@@ -8,7 +8,6 @@ package org.antlr.v4.runtime.dfa;
 import org.antlr.v4.runtime.misc.NotNull;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -69,11 +68,13 @@ public final class HashEdgeMap<T> extends AbstractEdgeMap<T> {
 		return key & (values.length - 1);
 	}
 
-	public final AtomicIntegerArray getKeys() {
+	@NotNull
+	/*package*/ AtomicIntegerArray getKeys() {
 		return keys;
 	}
 
-	public final T[] getValues() {
+	@NotNull
+	/*package*/ T[] getValues() {
 		return values;
 	}
 


### PR DESCRIPTION
* Fix warnings about use of deprecated types
* Remove unnecessary exposure of HashEdgeMap internals
