### PR TITLE
Fix antlr/antlr4#1890 Standalone CR should be recognized as line separator

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -213,3 +213,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/11/29, hannemann-tamas, Ralf Hannemann-Tamas, ralf.ht@gmail.com
 2018/12/20, WalterCouto, Walter Couto, WalterCouto@users.noreply.github.com
 2018/12/23, youkaichao, Kaichao You, youkaichao@gmail.com
+2019/03/24, nixel2007, Nikita Gryzlov, nixel2007@gmail.com

--- a/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
+++ b/runtime/Java/src/org/antlr/v4/runtime/atn/LexerATNSimulator.java
@@ -731,8 +731,13 @@ public class LexerATNSimulator extends ATNSimulator {
 		if ( curChar=='\n' ) {
 			line++;
 			charPositionInLine=0;
-		}
-		else {
+		} else if ( curChar == '\r' ) {
+			int nextChar = input.LA(2);
+			if ( nextChar != '\n') {
+				line++;
+				charPositionInLine=0;
+			}
+		} else {
 			charPositionInLine++;
 		}
 		input.consume();


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->

Hello!

I've made changes to treat stand-alone CR as line separator.
This changes were tested on millions of LOC with-out any noticable perfomance regress. Also I use my fork to parse files everyday as a part of static analysis process.

P.S. [Link to my PR](https://github.com/antlr/antlr4/pull/2519) to original ANTLR4 repo opened half an year ago...